### PR TITLE
Update to 1.46.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nghttp2" %}
-{% set version = "1.41.0" %}
+{% set version = "1.46.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/nghttp2/{{ name }}/releases/download/v{{ version }}/nghttp2-{{ version }}.tar.gz
-  sha256: eacc6f0f8543583ecd659faf0a3f906ed03826f1d4157b536b4b385fe47c5bb8
+  sha256: 4b6d11c85f2638531d1327fe1ed28c1e386144e8841176c04153ed32a4878208
 
 build:
-  number: 2
+  number: 0
   skip: true  # [not unix]
 
 requirements:
@@ -19,7 +19,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
-    - pkg-config  # [unix]
+    - pkg-config >=0.20  # [unix]
   host:
     - zlib
     - openssl  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,11 @@ requirements:
 outputs:
   - name: libnghttp2
     script: install.sh  # [unix]
+    build:
+      run_exports:
+        - {{ pin_subpackage('libnghttp2') }}
+      missing_dso_whitelist:
+        - $RPATH/ld64.so.1  # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -52,9 +57,6 @@ outputs:
         - libev >=4.11
         - c-ares >=1.7.5
         - libstdcxx-ng  # [linux]
-    build:
-      run_exports:
-        - {{ pin_subpackage('libnghttp2') }}
     files:
       - include/nghttp2/nghttp2*  # [unix]
       - lib/libnghttp2*  # [unix]


### PR DESCRIPTION
Version change: bump version number from 1.41.0 to 1.46.0
Bug Tracker: new open issues https://github.com/nghttp2/nghttp2/issues
Github releases:  https://github.com/nghttp2/nghttp2/releases
Upstream license:  License file:  https://github.com/nghttp2/nghttp2/blob/master/COPYING
Upstream Changelog: https://nghttp2.org/blog/2021/10/19/nghttp2-v1-46-0/

The package nghttp2 is mentioned inside the packages:
curl | priority |

Actions:
1. Update dependencies
2. Reset build number to 0
3. Add missing_dso_whitelist:
        `- $RPATH/ld64.so.1  # [s390x]`

Result:
- all-succeeded
