### PR TITLE
Update to 1.52.0 and compile with OpenSSL 3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,8 @@ channels:
   staging_openssl3: openssl3
 
 aggregate_branch: openssl3_builds
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -2,8 +2,7 @@ make install
 
 if [[ "$PKG_NAME" == *static ]]
 then
-	# relying on conda to dedup package
-	echo "Keeping all files, conda will dedupe"
+	rm -rfv ${PREFIX}/bin/*
 else
-	rm -rf ${PREFIX}/lib/*.a
+	rm -rfv ${PREFIX}/lib/*.a
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - c-ares >=1.7.5
   run:
     - zlib
-    - openssl  # [unix]
+    - openssl 3.*  # [unix]
     - libev >=4.11
     - c-ares >=1.7.5
     - libstdcxx-ng  # [linux]
@@ -53,7 +53,7 @@ outputs:
         - c-ares >=1.7.5
       run:
         - zlib
-        - openssl  # [unix]
+        - openssl 3.*  # [unix]
         - libev >=4.11
         - c-ares >=1.7.5
         - libstdcxx-ng  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nghttp2" %}
-{% set version = "1.46.0" %}
+{% set version = "1.52.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/nghttp2/{{ name }}/releases/download/v{{ version }}/nghttp2-{{ version }}.tar.gz
-  sha256: 4b6d11c85f2638531d1327fe1ed28c1e386144e8841176c04153ed32a4878208
+  sha256: 9877caa62bd72dde1331da38ce039dadb049817a01c3bdee809da15b754771b8
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - pkg-config >=0.20  # [unix]
   host:
     - zlib
-    - openssl  # [unix]
+    - openssl 3.0.8  # [unix]
     - libev >=4.11
     - c-ares >=1.7.5
   run:
@@ -89,7 +89,7 @@ outputs:
         - test -f ${PREFIX}/lib/lib{{ name }}.a    # [unix]
 
 about:
-  home: http://github.com/nghttp2/nghttp2
+  home: https://github.com/nghttp2/nghttp2
   license: MIT
   license_family: MIT
   license_file: COPYING


### PR DESCRIPTION
Update to 1.52.0 and compile with OpenSSL 3.

Upstream diff: https://github.com/nghttp2/nghttp2/compare/v1.46.0..v1.52.0
Conda-forge diff: https://github.com/conda-forge/nghttp2-feedstock/compare/b388aefdee750fd3765076c291873d9bd106c021..85d30eac0acddee4f62c6b5e11945e4a7525275a
