### PR TITLE
Update version to 1.69.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,5 @@ cxx_compiler_version:      # [linux or osx]
   - 15.2.0                 # [linux]
 fortran_compiler_version:
   - 14.3.0                 # [osx or linux]
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nghttp2" %}
-{% set version = "1.68.1" %}
+{% set version = "1.69.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ceb434c1f9dfe2a9d305b6b797786fb9227484dfa88508d14ca1c50263db55d3
+  sha256: c866b7477cbb7512ab6863a685027adbb1bb8da8fc3bab7429ed43d3281d5aa9
 
 build:
   number: 0


### PR DESCRIPTION
nghttp2 1.69.0

**Destination channel:**  defaults

### Links

- [PKG-14324](https://anaconda.atlassian.net/browse/PKG-14324) 
- [Upstream repository](https://github.com/nghttp2/nghttp2/tree/v1.68.1)

### Explanation of changes:
- New version number
- Updated libxml2 version


[PKG-14324]: https://anaconda.atlassian.net/browse/PKG-14324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ